### PR TITLE
Add ReportError method to CollectorLog and test #22

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,4 +91,4 @@ if (!influxResult.Success)
 
 ## Status
 
-This project is still undergoing some change while in development, but the core functionality is stabilizing. See issues tagged `enhancement` for roadmap items. It's currently targeting .NET 4.5.1 and .NET Core using Visual Studio 2015.
+This project is still undergoing some change while in development, but the core functionality is stabilizing. See issues tagged `enhancement` for roadmap items. It's currently targeting .NET 4.5.1 and .NET Core using Visual Studio 2017.

--- a/src/InfluxDB.Collector/Diagnostics/CollectorLog.cs
+++ b/src/InfluxDB.Collector/Diagnostics/CollectorLog.cs
@@ -1,15 +1,37 @@
 ﻿using System;
-using System.IO;
+using System.Collections.Concurrent;
+using InfluxDB.Collector.Util;
 
 namespace InfluxDB.Collector.Diagnostics
 {
     public static class CollectorLog
     {
-        public static TextWriter Out { get; set; } = Console.Error;
+        private static readonly ConcurrentDictionary<Action<string, Exception>, object> ErrorHandlers = new ConcurrentDictionary<Action<string, Exception>, object>();
 
-        public static void WriteLine(string format, params object[] args)
+        /// <summary>
+        /// Registers an error handler. Errors reported may not neccessarily always correspond with an exception. That is to say, when the callback is invoked, the exception may be null.
+        /// To unregister a handler, simply dispose of the IDisposable returned from this method
+        /// The order in which handlers are invoked is not defined
+        /// </summary>
+        /// <param name="errorHandler">A func accepting a string and an exception. Note that exception may be null when invoked</param>
+        /// <returns>An IDispoable which when explicitly disposed, will unnregister the handler</returns>
+        public static IDisposable RegisterErrorHandler(Action<string, Exception> errorHandler)
         {
-            Out?.WriteLine(format, args);
+            ErrorHandlers.TryAdd(errorHandler, errorHandler);
+            return new DisposableAction(() => ErrorHandlers.TryRemove(errorHandler, out object junk));
+        }
+
+        internal static void ReportError(string message, Exception exception)
+        {
+            foreach (var errorHandler in ErrorHandlers)
+            {
+                errorHandler.Key(message, exception);
+            }
+        }
+
+        internal static void ClearHandlers()
+        {
+            ErrorHandlers.Clear();
         }
     }
 }

--- a/src/InfluxDB.Collector/InfluxDB.Collector.csproj
+++ b/src/InfluxDB.Collector/InfluxDB.Collector.csproj
@@ -32,6 +32,7 @@
     <PackageReference Include="System.Net.Http" Version="4.1.1" />
     <PackageReference Include="System.Console" Version="4.0.0" />
     <PackageReference Include="System.Runtime.Extensions" Version="4.1.0" />
+    <PackageReference Include="System.Collections.Concurrent" Version="4.0.12" />
   </ItemGroup>
 
 </Project>

--- a/src/InfluxDB.Collector/InfluxDB.Collector.csproj
+++ b/src/InfluxDB.Collector/InfluxDB.Collector.csproj
@@ -32,7 +32,6 @@
     <PackageReference Include="System.Net.Http" Version="4.1.1" />
     <PackageReference Include="System.Console" Version="4.0.0" />
     <PackageReference Include="System.Runtime.Extensions" Version="4.1.0" />
-    <PackageReference Include="System.Collections.Concurrent" Version="4.0.12" />
   </ItemGroup>
 
 </Project>

--- a/src/InfluxDB.Collector/MetricsCollector.cs
+++ b/src/InfluxDB.Collector/MetricsCollector.cs
@@ -43,7 +43,7 @@ namespace InfluxDB.Collector
             }
             catch (Exception ex)
             {
-                CollectorLog.WriteLine("Failed to write point: {0}", ex);
+                CollectorLog.ReportError("Failed to write point", ex);
             }
         }
 

--- a/src/InfluxDB.Collector/Pipeline/Batch/IntervalBatcher.cs
+++ b/src/InfluxDB.Collector/Pipeline/Batch/IntervalBatcher.cs
@@ -63,7 +63,7 @@ namespace InfluxDB.Collector.Pipeline.Batch
             }
             catch (Exception ex)
             {
-                CollectorLog.WriteLine("Failed to emit metrics batch: {0}", ex);
+                CollectorLog.ReportError("Failed to emit metrics batch", ex);
             }
             finally
             {

--- a/src/InfluxDB.Collector/Pipeline/Emit/HttpLineProtocolEmitter.cs
+++ b/src/InfluxDB.Collector/Pipeline/Emit/HttpLineProtocolEmitter.cs
@@ -31,7 +31,7 @@ namespace InfluxDB.Collector.Pipeline.Emit
 
             var influxResult = _client.WriteAsync(payload).Result;
             if (!influxResult.Success)
-                CollectorLog.WriteLine(influxResult.ErrorMessage);
+                CollectorLog.ReportError(influxResult.ErrorMessage, null);
         }
     }
 }

--- a/src/InfluxDB.Collector/Properties/AssemblyInfo.cs
+++ b/src/InfluxDB.Collector/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly:InternalsVisibleTo("InfluxDB.LineProtocol.Tests")]

--- a/src/InfluxDB.Collector/Util/DisposableAction.cs
+++ b/src/InfluxDB.Collector/Util/DisposableAction.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Threading;
+
+namespace InfluxDB.Collector.Util
+{
+    internal class DisposableAction : IDisposable
+    {
+        private readonly Action _disposeAction;
+        private int _disposeCount;
+
+        public DisposableAction(Action disposeAction)
+        {
+            if (disposeAction == null) throw new ArgumentNullException(nameof(disposeAction));
+            _disposeAction = disposeAction;
+        }
+
+        public void Dispose()
+        {
+            // Only dispose on first call
+            if (Interlocked.Increment(ref _disposeCount) == 1)
+                _disposeAction();
+        }
+    }
+}

--- a/test/InfluxDB.LineProtocol.Tests/Collector/CollectorLogTests.cs
+++ b/test/InfluxDB.LineProtocol.Tests/Collector/CollectorLogTests.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using InfluxDB.Collector.Diagnostics;
+using Xunit;
+
+namespace InfluxDB.LineProtocol.Tests.Collector
+{
+    public class CollectorLogTests : IDisposable
+    {
+        public CollectorLogTests()
+        {
+            CollectorLog.ClearHandlers();
+        }
+
+        [Fact]
+        public void CanReportWithoutListeners()
+        {
+            CollectorLog.ReportError("", null);
+        }
+
+        [Fact]
+        public void SingleListenerGetsInvoked()
+        {
+            var invocationCount = 0;
+            Exception dummyException = new Exception("Bang!");
+            const string errorMessage = "Bad things";
+
+            CollectorLog.RegisterErrorHandler((message, exception) =>
+            {
+                Assert.Equal(errorMessage, message);
+                Assert.Equal(dummyException, exception);
+                invocationCount++;
+            });
+
+            CollectorLog.ReportError(errorMessage, dummyException);
+            Assert.Equal(1, invocationCount);
+        }
+
+        [Fact]
+        public void AllListenersGetInvoked()
+        {
+            var invocationCount = 0;
+            Exception dummyException = new Exception("Bang!");
+            const string errorMessage = "Bad things";
+
+            CollectorLog.RegisterErrorHandler((message, exception) =>
+            {
+                Assert.Equal(errorMessage, message);
+                Assert.Equal(dummyException, exception);
+                invocationCount++;
+            });
+            CollectorLog.RegisterErrorHandler((message, exception) => invocationCount++);
+
+            CollectorLog.ReportError(errorMessage, dummyException);
+            Assert.Equal(2, invocationCount);
+        }
+
+        [Fact]
+        public void ListenerCanUnregister()
+        {
+            var invocationCount = 0;
+            using (CollectorLog.RegisterErrorHandler((message, exception) => invocationCount++))
+            {
+                CollectorLog.ReportError("", null);
+            }
+            CollectorLog.ReportError("", null);
+            Assert.Equal(1, invocationCount);
+        }
+
+        [Fact]
+        public void EnsureListenerExceptionPropagates()
+        {
+            CollectorLog.RegisterErrorHandler((message, exception) =>
+            {
+                throw new Exception("");
+            });
+
+            var threw = false;
+            try
+            {
+                CollectorLog.ReportError("", null);
+            }
+            catch
+            {
+                threw = true;
+            }
+            Assert.True(threw, "Excpected an exception thrown by the error handler to propagate to the caller");
+        }
+
+        public void Dispose()
+        {
+            CollectorLog.ClearHandlers();
+        }
+    }
+}


### PR DESCRIPTION
This removes the old WriteLine method and replaces it with a facility to register error handlers that will receive both the message and optionally the exception that caused the error. Also provides finer grained controls, enabling multiple handlers to be registered.