### PR TITLE
Build InfluxDB.Collector  nuget package with the correct dependency version suffix.

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -4,18 +4,18 @@ echo "build: Build started"
 
 Push-Location $PSScriptRoot
 
-if(Test-Path .\artifacts) {
-	echo "build: Cleaning .\artifacts"
-	Remove-Item .\artifacts -Force -Recurse
-}
-
-& dotnet restore --no-cache
-
 $branch = @{ $true = $env:APPVEYOR_REPO_BRANCH; $false = $(git symbolic-ref --short -q HEAD) }[$env:APPVEYOR_REPO_BRANCH -ne $NULL];
 $revision = @{ $true = "{0:00000}" -f [convert]::ToInt32("0" + $env:APPVEYOR_BUILD_NUMBER, 10); $false = "local" }[$env:APPVEYOR_BUILD_NUMBER -ne $NULL];
 $suffix = @{
 	$true = "beta-$revision";
 	$false = "$($branch.Substring(0, [math]::Min(10,$branch.Length)))-$revision"}[$branch -eq "master" -and $revision -ne "local"]
+
+if(Test-Path .\artifacts) {
+	echo "build: Cleaning .\artifacts"
+	Remove-Item .\artifacts -Force -Recurse
+}
+
+& dotnet msbuild "/t:Restore" /p:VersionSuffix=$suffix /p:Configuration=Release
 
 echo "build: Version suffix is $suffix"
 


### PR DESCRIPTION
Turns out I broke our packages on nuget with the vs2017 migration - woops! This PR fixes that.
If you check out https://www.nuget.org/packages/InfluxDB.Collector/1.0.0-beta-10060 -you'll see it depends on `InfluxDB.LineProtocol (>= 1.0.0)`, which doesn't exist! It should be `InfluxDB.LineProtocol (>= 1.0.0-beta-10060)`.

This causes package installs to fail everywhere, unless you manually poke the csproj to get the references going.

This is caused by a bug in nuget/dotnet when doing restore/pack. It is outlined here: https://github.com/NuGet/Home/issues/4337