### PR TITLE
Writer benchmark

### DIFF
--- a/influxdb-csharp.sln
+++ b/influxdb-csharp.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26228.9
+VisualStudioVersion = 15.0.26730.3
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{72DC28B9-37B5-425C-8532-5CA91D253A70}"
 EndProject
@@ -29,6 +29,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sample", "sample\Sample\Sam
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "InfluxDB.Collector", "src\InfluxDB.Collector\InfluxDB.Collector.csproj", "{F690F3E3-D9F0-441A-9E70-4F70998BDD1B}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Benchmark", "sample\Benchmark\Benchmark.csproj", "{2A34EE83-FB59-4A41-8BB5-174BE678533E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -51,6 +53,10 @@ Global
 		{F690F3E3-D9F0-441A-9E70-4F70998BDD1B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F690F3E3-D9F0-441A-9E70-4F70998BDD1B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F690F3E3-D9F0-441A-9E70-4F70998BDD1B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2A34EE83-FB59-4A41-8BB5-174BE678533E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2A34EE83-FB59-4A41-8BB5-174BE678533E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2A34EE83-FB59-4A41-8BB5-174BE678533E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2A34EE83-FB59-4A41-8BB5-174BE678533E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -60,5 +66,9 @@ Global
 		{34173CA2-1551-4E46-B8E7-E4629A48E415} = {75C71D21-E6FD-493F-A355-997EEF4DDF11}
 		{DC6028D6-ED1D-4857-B5EB-28BA05E3F531} = {CD65EE64-FDA8-4ED9-A7F2-81BDD9F64C64}
 		{F690F3E3-D9F0-441A-9E70-4F70998BDD1B} = {72DC28B9-37B5-425C-8532-5CA91D253A70}
+		{2A34EE83-FB59-4A41-8BB5-174BE678533E} = {CD65EE64-FDA8-4ED9-A7F2-81BDD9F64C64}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {AB0C6BCE-235A-4018-8644-7652EC826FF5}
 	EndGlobalSection
 EndGlobal

--- a/sample/Benchmark/.gitignore
+++ b/sample/Benchmark/.gitignore
@@ -1,0 +1,1 @@
+BenchmarkDotNet.Artifacts

--- a/sample/Benchmark/Benchmark.csproj
+++ b/sample/Benchmark/Benchmark.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net46</TargetFrameworks>
+    <AssemblyName>Sample</AssemblyName>
+    <PackageId>Sample</PackageId>
+    <ApplicationIcon />
+    <OutputType>Exe</OutputType>
+    <StartupObject />
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.10.9" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.10.9" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\InfluxDB.LineProtocol\InfluxDB.LineProtocol.csproj" />
+  </ItemGroup>
+</Project>

--- a/sample/Benchmark/EscapeTagNames.cs
+++ b/sample/Benchmark/EscapeTagNames.cs
@@ -1,0 +1,73 @@
+using System.IO;
+using BenchmarkDotNet.Attributes;
+
+namespace Benchmark
+{
+    [MemoryDiagnoser]
+    public class EscapeTagNames
+    {
+        private const int N = 500;
+
+        [Params("my_tag", "my tag")]
+        public string TagName { get; set; }
+
+        [Benchmark(Baseline = true)]
+        public string NoEscaping()
+        {
+            var writer = new StringWriter();
+
+            for (var i = 0; i < N; i++)
+            {
+                writer.Write(TagName);
+            }
+
+            return writer.ToString();
+        }
+
+        [Benchmark]
+        public string Replace()
+        {
+            var writer = new StringWriter();
+
+            for (var i = 0; i < N; i++)
+            {
+                writer.Write(TagName
+                    .Replace("=", "\\=")
+                    .Replace(" ", "\\ ")
+                    .Replace(",", "\\,"));
+            }
+
+            return writer.ToString();
+        }
+
+        [Benchmark]
+        public string WriteCharOrEscapeString()
+        {
+            var writer = new StringWriter();
+
+            for (var i = 0; i < N; i++)
+            {
+                foreach (char c in TagName)
+                {
+                    switch (c)
+                    {
+                        case ' ':
+                            writer.Write("\\ ");
+                            break;
+                        case ',':
+                            writer.Write("\\,");
+                            break;
+                        case '=':
+                            writer.Write("\\=");
+                            break;
+                        default:
+                            writer.Write(c);
+                            break;
+                    }
+                }
+            }
+
+            return writer.ToString();
+        }
+    }
+}

--- a/sample/Benchmark/Program.cs
+++ b/sample/Benchmark/Program.cs
@@ -1,0 +1,12 @@
+﻿namespace Benchmark
+{
+    using BenchmarkDotNet.Running;
+
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            BenchmarkRunner.Run<WriteLineProtocol>();
+        }
+    }
+}

--- a/sample/Benchmark/WriteLineProtocol.cs
+++ b/sample/Benchmark/WriteLineProtocol.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using BenchmarkDotNet.Attributes;
+using InfluxDB.LineProtocol;
+using InfluxDB.LineProtocol.Payload;
+
+namespace Benchmark
+{
+    [MemoryDiagnoser]
+    public class WriteLineProtocol
+    {
+        private const int N = 500;
+
+        private static readonly string[] Colours = { "red", "blue", "green" };
+
+        private readonly (DateTime timestamp, string colour, double value)[] data;
+
+        public WriteLineProtocol()
+        {
+            var random = new Random(755);
+            var now = DateTime.UtcNow;
+            data = Enumerable.Range(0, N).Select(i => (now.AddMilliseconds(random.Next(2000)), Colours[random.Next(Colours.Length)], random.NextDouble())).ToArray();
+        }
+
+        [Benchmark(Baseline = true)]
+        public string LineProtocolPoint()
+        {
+            var payload = new LineProtocolPayload();
+
+            foreach (var point in data)
+            {
+                payload.Add(new LineProtocolPoint(
+                    "example",
+                    new Dictionary<string, object>
+                    {
+                        {"value", point.value}
+                    },
+                    new Dictionary<string, string>
+                    {
+                        {"colour", point.colour}
+                    },
+                    point.timestamp
+                ));
+            }
+
+            var writer = new StringWriter();
+            payload.Format(writer);
+            return writer.ToString();
+        }
+
+        [Benchmark]
+        public string LineProtocolWriter()
+        {
+            var writer = new LineProtocolWriter();
+
+            foreach (var point in data)
+            {
+                writer.Measurement("example").Tag("colour", point.colour).Field("value", point.value).Timestamp(point.timestamp);
+            }
+
+            return writer.ToString();
+        }
+
+        [Benchmark]
+        public string StringInterpolation()
+        {
+            var unixEpoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+            var lines = new List<string>();
+
+            foreach (var point in data)
+            {
+                var timestamp = point.timestamp - unixEpoch;
+                lines.Add($"example,colour={point.colour} value={point.value} {timestamp.Ticks * 100L}");
+            }
+
+            return string.Join("\n", lines);
+        }
+
+        [Benchmark]
+        public string StringBuilder()
+        {
+            var unixEpoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+            var lines = new StringBuilder();
+
+            foreach (var point in data)
+            {
+                var timestamp = point.timestamp - unixEpoch;
+                lines.Append("example,colour=").Append(point.colour).Append(" value=").Append(point.value).Append(" ").Append(timestamp.Ticks * 100L).Append("\n");
+            }
+
+            return lines.ToString();
+        }
+    }
+}


### PR DESCRIPTION
Added a benchmark project.
Unfortunately I could only get the benchmark project running on full dot net. But I think this should be OK as it only a test bench.

I added a benchmark to compare writing a simple measurement with one tag and one value using `LineProtocolPoint` (the base line) and `LineProtocolWriter`.
I also added for comparison using string interpolation. Which I think is a good representation of how someone might do it if no framework existed.
```
lines.Add($"example,colour={point.colour} value={point.value} {timestamp.Ticks * 100L}");
```
And also using `StringBuilder` which, as this is what we are using, represents the best we could achieve.
```
lines.Append("example,colour=").Append(point.colour).Append(" value=").Append(point.value).Append(" ").Append(timestamp.Ticks * 100L).Append("\n")
```

Results on my machine:


``` ini

BenchmarkDotNet=v0.10.9, OS=Windows 10 Redstone 2 (10.0.15063)
Processor=Intel Core i7-6700HQ CPU 2.60GHz (Skylake), ProcessorCount=8
Frequency=2531249 Hz, Resolution=395.0619 ns, Timer=TSC
  [Host]     : .NET Framework 4.7 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.2102.0
  DefaultJob : .NET Framework 4.7 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.2102.0


```
 |              Method |       Mean |     Error |    StdDev | Scaled | ScaledSD |    Gen 0 |   Gen 1 | Allocated |
 |-------------------- |-----------:|----------:|----------:|-------:|---------:|---------:|--------:|----------:|
 |   LineProtocolPoint | 1,209.4 us | 10.342 us |  9.673 us |   1.00 |     0.00 | 130.8594 | 42.9688 | 669.81 KB |
 |  LineProtocolWriter |   636.0 us |  8.844 us |  7.840 us |   0.53 |     0.01 |  60.5469 |       - | 188.96 KB |
 | StringInterpolation |   590.1 us | 11.596 us | 24.461 us |   0.49 |     0.02 |  86.6536 | 26.6927 | 308.29 KB |
 |       StringBuilder |   409.7 us |  8.354 us | 13.251 us |   0.34 |     0.01 |  61.0352 |       - | 188.83 KB |

I did some profiling and found that I could impove the speed of `LineProtocolWriter` by refactoring the escape name implementation.
I have added a benchmark for that work.

after:
 
 ``` ini

BenchmarkDotNet=v0.10.9, OS=Windows 10 Redstone 2 (10.0.15063)
Processor=Intel Core i7-6700HQ CPU 2.60GHz (Skylake), ProcessorCount=8
Frequency=2531249 Hz, Resolution=395.0619 ns, Timer=TSC
  [Host]     : .NET Framework 4.7 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.2102.0
  DefaultJob : .NET Framework 4.7 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.2102.0


```
 |              Method |       Mean |     Error |    StdDev | Scaled |    Gen 0 |   Gen 1 | Allocated |
 |-------------------- |-----------:|----------:|----------:|-------:|---------:|--------:|----------:|
 |   LineProtocolPoint | 1,220.6 us | 19.701 us | 18.429 us |   1.00 | 130.8594 | 42.9688 | 669.81 KB |
 |  LineProtocolWriter |   462.7 us |  9.836 us | 14.722 us |   0.38 |  61.0352 |       - | 188.95 KB |
 | StringInterpolation |   554.9 us |  4.862 us |  4.548 us |   0.45 |  86.2534 | 27.6023 | 308.29 KB |
 |       StringBuilder |   399.3 us |  2.975 us |  2.783 us |   0.33 |  61.0352 |       - | 188.83 KB |
