### PR TITLE
Precision

### DIFF
--- a/src/InfluxDB.LineProtocol/Client/LineProtocolClient.cs
+++ b/src/InfluxDB.LineProtocol/Client/LineProtocolClient.cs
@@ -44,7 +44,7 @@ namespace InfluxDB.LineProtocol.Client
             return SendAsync(writer.ToString(), writer.Precision, cancellationToken);
         }
 
-        private async Task<LineProtocolWriteResult> SendAsync(string payload, Precision precision = Precision.Nanoseconds, CancellationToken cancellationToken = default(CancellationToken))
+        private async Task<LineProtocolWriteResult> SendAsync(string payload, Precision precision, CancellationToken cancellationToken = default(CancellationToken))
         {
             var endpoint = $"write?db={Uri.EscapeDataString(_database)}";
             if (!string.IsNullOrEmpty(_username))

--- a/src/InfluxDB.LineProtocol/Client/LineProtocolClient.cs
+++ b/src/InfluxDB.LineProtocol/Client/LineProtocolClient.cs
@@ -32,16 +32,16 @@ namespace InfluxDB.LineProtocol.Client
 
         public Task<LineProtocolWriteResult> WriteAsync(LineProtocolPayload payload, CancellationToken cancellationToken = default(CancellationToken))
         {
-            var writer = new StringWriter();
+            var stringWriter = new StringWriter();
 
-            payload.Format(writer);
+            payload.Format(stringWriter);
 
-            return SendAsync(writer.ToString(), Precision.Nanoseconds, cancellationToken);
+            return SendAsync(stringWriter.ToString(), Precision.Nanoseconds, cancellationToken);
         }
 
-        public Task<LineProtocolWriteResult> SendAsync(LineProtocolWriter writer, CancellationToken cancellationToken = default(CancellationToken))
+        public Task<LineProtocolWriteResult> SendAsync(LineProtocolWriter lineProtocolWriter, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return SendAsync(writer.ToString(), writer.Precision, cancellationToken);
+            return SendAsync(lineProtocolWriter.ToString(), lineProtocolWriter.Precision, cancellationToken);
         }
 
         private async Task<LineProtocolWriteResult> SendAsync(string payload, Precision precision, CancellationToken cancellationToken = default(CancellationToken))

--- a/src/InfluxDB.LineProtocol/LineProtocolWriter.cs
+++ b/src/InfluxDB.LineProtocol/LineProtocolWriter.cs
@@ -183,18 +183,18 @@ namespace InfluxDB.LineProtocol
             return this;
         }
 
-        public void Timestamp(long nanoseconds, PrecisionResolutionStrategy? resolutionStrategy = null)
+        public void Timestamp(long nanoseconds)
         {
-            if (!resolutionStrategy.HasValue)
-            {
-                resolutionStrategy = defaultResolutionStrategy;
-            }
+            this.Timestamp(nanoseconds, defaultResolutionStrategy);
+        }
 
+        public void Timestamp(long nanoseconds, PrecisionResolutionStrategy resolutionStrategy)
+        {
             var nanosecondsAbovePrecision = nanoseconds % (long)Precision;
 
             if (nanosecondsAbovePrecision != 0)
             {
-                switch (resolutionStrategy.Value)
+                switch (resolutionStrategy)
                 {
                     case PrecisionResolutionStrategy.Error:
                         throw new ArgumentOutOfRangeException(nameof(nanoseconds));
@@ -236,17 +236,32 @@ namespace InfluxDB.LineProtocol
             position = LinePosition.TimestampWritten;
         }
 
-        public void Timestamp(TimeSpan value, PrecisionResolutionStrategy? resolutionStrategy = null)
+        public void Timestamp(TimeSpan value)
+        {
+            Timestamp(value, defaultResolutionStrategy);
+        }
+
+        public void Timestamp(TimeSpan value, PrecisionResolutionStrategy resolutionStrategy)
         {
             Timestamp(value.Ticks * 100, resolutionStrategy);
         }
 
-        public void Timestamp(DateTimeOffset value, PrecisionResolutionStrategy? resolutionStrategy = null)
+        public void Timestamp(DateTimeOffset value)
+        {
+            Timestamp(value, defaultResolutionStrategy);
+        }
+
+        public void Timestamp(DateTimeOffset value, PrecisionResolutionStrategy resolutionStrategy)
         {
             Timestamp(value.UtcDateTime, resolutionStrategy);
         }
 
-        public void Timestamp(DateTime value, PrecisionResolutionStrategy? resolutionStrategy = null)
+        public void Timestamp(DateTime value)
+        {
+            Timestamp(value, defaultResolutionStrategy);
+        }
+
+        public void Timestamp(DateTime value, PrecisionResolutionStrategy resolutionStrategy)
         {
             if (value != null && value.Kind != DateTimeKind.Utc)
             {

--- a/src/InfluxDB.LineProtocol/LineProtocolWriter.cs
+++ b/src/InfluxDB.LineProtocol/LineProtocolWriter.cs
@@ -190,22 +190,22 @@ namespace InfluxDB.LineProtocol
                 resolutionStrategy = defaultResolutionStrategy;
             }
 
-            var nanoSecondsAbovePrecision = nanoseconds % (long)Precision;
+            var nanosecondsAbovePrecision = nanoseconds % (long)Precision;
 
-            if (nanoSecondsAbovePrecision != 0)
+            if (nanosecondsAbovePrecision != 0)
             {
                 switch (resolutionStrategy.Value)
                 {
                     case PrecisionResolutionStrategy.Error:
                         throw new ArgumentOutOfRangeException(nameof(nanoseconds));
                     case PrecisionResolutionStrategy.Floor:
-                        nanoseconds -= nanoSecondsAbovePrecision;
+                        nanoseconds -= nanosecondsAbovePrecision;
                         break;
                     case PrecisionResolutionStrategy.Ceiling:
-                        nanoseconds += (long)Precision - nanoSecondsAbovePrecision;
+                        nanoseconds += (long)Precision - nanosecondsAbovePrecision;
                         break;
                     case PrecisionResolutionStrategy.Round:
-                        if (nanoSecondsAbovePrecision < (long)Precision / 2)
+                        if (nanosecondsAbovePrecision < (long)Precision / 2)
                         {
                             Timestamp(nanoseconds, PrecisionResolutionStrategy.Floor);
                         }

--- a/src/InfluxDB.LineProtocol/Precision.cs
+++ b/src/InfluxDB.LineProtocol/Precision.cs
@@ -1,0 +1,12 @@
+namespace InfluxDB.LineProtocol
+{
+    public enum Precision : long
+    {
+        Nanoseconds = 1,
+        Microseconds = 1000,
+        Milliseconds = Microseconds * 1000,
+        Seconds = Milliseconds * 1000,
+        Minutes = Seconds * 60,
+        Hours = Minutes * 60
+    }
+}

--- a/src/InfluxDB.LineProtocol/PrecisionResolutionStrategies.cs
+++ b/src/InfluxDB.LineProtocol/PrecisionResolutionStrategies.cs
@@ -1,0 +1,10 @@
+namespace InfluxDB.LineProtocol
+{
+    public enum PrecisionResolutionStrategies
+    {
+        Error,
+        Round,
+        Floor,
+        Ceiling
+    }
+}

--- a/src/InfluxDB.LineProtocol/PrecisionResolutionStrategy.cs
+++ b/src/InfluxDB.LineProtocol/PrecisionResolutionStrategy.cs
@@ -1,7 +1,8 @@
 namespace InfluxDB.LineProtocol
 {
-    public enum PrecisionResolutionStrategies
+    public enum PrecisionResolutionStrategy
     {
+        Undefined = 0,
         Error,
         Round,
         Floor,

--- a/src/InfluxDB.LineProtocol/PrecisionResolutionStrategy.cs
+++ b/src/InfluxDB.LineProtocol/PrecisionResolutionStrategy.cs
@@ -2,7 +2,6 @@ namespace InfluxDB.LineProtocol
 {
     public enum PrecisionResolutionStrategy
     {
-        Undefined = 0,
         Error,
         Round,
         Floor,

--- a/test/InfluxDB.LineProtocol.Tests/LineProtocolWriterPrecisionTests.cs
+++ b/test/InfluxDB.LineProtocol.Tests/LineProtocolWriterPrecisionTests.cs
@@ -39,5 +39,52 @@ namespace InfluxDB.LineProtocol.Tests
 
             Assert.Throws<ArgumentOutOfRangeException>(() => writer.Timestamp(timestamp));
         }
+
+        [Theory]
+        [InlineData(Precision.Microseconds)]
+        [InlineData(Precision.Milliseconds)]
+        [InlineData(Precision.Seconds)]
+        [InlineData(Precision.Hours)]
+        public void Can_floor_if_wrong_precision_used(Precision precision)
+        {
+            var writer = new LineProtocolWriter(precision);
+
+            var timestamp = TimeSpan.FromTicks(1);
+
+            writer.Measurement("foo").Field("bar", 1f).Timestamp(timestamp, PrecisionResolutionStrategies.Floor);
+
+            Assert.Equal("foo bar=1 0", writer.ToString());
+        }
+
+        [Theory]
+        [InlineData(Precision.Microseconds)]
+        [InlineData(Precision.Milliseconds)]
+        [InlineData(Precision.Seconds)]
+        [InlineData(Precision.Hours)]
+        public void Can_ceiling_if_wrong_precision_used(Precision precision)
+        {
+            var writer = new LineProtocolWriter(precision);
+
+            var timestamp = TimeSpan.FromTicks(1);
+
+            writer.Measurement("foo").Field("bar", 1f).Timestamp(timestamp, PrecisionResolutionStrategies.Ceiling);
+
+            Assert.Equal("foo bar=1 1", writer.ToString());
+        }
+
+        [Theory]
+        [InlineData(Precision.Microseconds)]
+        [InlineData(Precision.Milliseconds)]
+        [InlineData(Precision.Seconds)]
+        [InlineData(Precision.Hours)]
+        public void Can_round_if_wrong_precision_used(Precision precision)
+        {
+            var writer = new LineProtocolWriter(precision);
+
+            writer.Measurement("foo").Field("bar", true).Timestamp(TimeSpan.FromTicks(1), PrecisionResolutionStrategies.Round);
+            writer.Measurement("foo").Field("bar", true).Timestamp(TimeSpan.FromTicks(((long)precision / 100) - 1), PrecisionResolutionStrategies.Round);
+
+            Assert.Equal("foo bar=t 0\nfoo bar=t 1", writer.ToString());
+        }
     }
 }

--- a/test/InfluxDB.LineProtocol.Tests/LineProtocolWriterPrecisionTests.cs
+++ b/test/InfluxDB.LineProtocol.Tests/LineProtocolWriterPrecisionTests.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using Xunit;
+
+namespace InfluxDB.LineProtocol.Tests
+{
+    public class LineProtocolWriterPrecisionTests
+    {
+        [Theory]
+        [InlineData(Precision.Nanoseconds, 1500832764070165800, "1500832764070165800")]
+        [InlineData(Precision.Microseconds, 1500832764070165000, "1500832764070165")]
+        [InlineData(Precision.Milliseconds, 1500832764070000000, "1500832764070")]
+        [InlineData(Precision.Seconds, 1500832764000000000, "1500832764")]
+        [InlineData(Precision.Hours, 1500829200000000000, "416897")]
+        public void Will_write_timestamps_using_precision_of_writer(Precision precision, long nanoseconds, string expectedTimestamp)
+        {
+            var unixEpoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+            var timestamp = unixEpoch.AddTicks(nanoseconds / 100); // .net tick is 100 nanoseconds.
+
+            var writer = new LineProtocolWriter(precision);
+
+            writer.Measurement("foo").Field("bar", 1f).Timestamp(timestamp);
+
+            Assert.Equal($"foo bar=1 {expectedTimestamp}", writer.ToString());
+        }
+
+        [Theory]
+        [InlineData(Precision.Microseconds)]
+        [InlineData(Precision.Milliseconds)]
+        [InlineData(Precision.Seconds)]
+        [InlineData(Precision.Hours)]
+        public void Will_throw_if_wrong_precision_used(Precision precision)
+        {
+            var writer = new LineProtocolWriter(precision);
+
+            var timestamp = TimeSpan.FromTicks(1);
+
+            writer.Measurement("foo").Field("bar", 1f);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => writer.Timestamp(timestamp));
+        }
+    }
+}

--- a/test/InfluxDB.LineProtocol.Tests/LineProtocolWriterPrecisionTests.cs
+++ b/test/InfluxDB.LineProtocol.Tests/LineProtocolWriterPrecisionTests.cs
@@ -51,7 +51,7 @@ namespace InfluxDB.LineProtocol.Tests
 
             var timestamp = TimeSpan.FromTicks(1);
 
-            writer.Measurement("foo").Field("bar", 1f).Timestamp(timestamp, PrecisionResolutionStrategies.Floor);
+            writer.Measurement("foo").Field("bar", 1f).Timestamp(timestamp, PrecisionResolutionStrategy.Floor);
 
             Assert.Equal("foo bar=1 0", writer.ToString());
         }
@@ -67,7 +67,7 @@ namespace InfluxDB.LineProtocol.Tests
 
             var timestamp = TimeSpan.FromTicks(1);
 
-            writer.Measurement("foo").Field("bar", 1f).Timestamp(timestamp, PrecisionResolutionStrategies.Ceiling);
+            writer.Measurement("foo").Field("bar", 1f).Timestamp(timestamp, PrecisionResolutionStrategy.Ceiling);
 
             Assert.Equal("foo bar=1 1", writer.ToString());
         }
@@ -81,10 +81,32 @@ namespace InfluxDB.LineProtocol.Tests
         {
             var writer = new LineProtocolWriter(precision);
 
-            writer.Measurement("foo").Field("bar", true).Timestamp(TimeSpan.FromTicks(1), PrecisionResolutionStrategies.Round);
-            writer.Measurement("foo").Field("bar", true).Timestamp(TimeSpan.FromTicks(((long)precision / 100) - 1), PrecisionResolutionStrategies.Round);
+            writer.Measurement("foo").Field("bar", true).Timestamp(TimeSpan.FromTicks(1), PrecisionResolutionStrategy.Round);
+            writer.Measurement("foo").Field("bar", true).Timestamp(TimeSpan.FromTicks(((long)precision / 100) - 1), PrecisionResolutionStrategy.Round);
 
             Assert.Equal("foo bar=t 0\nfoo bar=t 1", writer.ToString());
+        }
+
+        [Fact]
+        public void Can_define_resolution_strategy_when_creating_the_writer()
+        {
+            var writer = new LineProtocolWriter(Precision.Seconds, PrecisionResolutionStrategy.Round);
+
+            writer.Measurement("foo").Field("bar", true).Timestamp(TimeSpan.FromMilliseconds(499));
+            writer.Measurement("foo").Field("bar", true).Timestamp(TimeSpan.FromMilliseconds(500));
+
+            Assert.Equal("foo bar=t 0\nfoo bar=t 1", writer.ToString());
+        }
+
+        [Fact]
+        public void Can_override_resolution_strategy_when_writing_point()
+        {
+            var writer = new LineProtocolWriter(Precision.Seconds, PrecisionResolutionStrategy.Round);
+
+            writer.Measurement("foo").Field("bar", true).Timestamp(TimeSpan.FromMilliseconds(700));
+            writer.Measurement("foo").Field("bar", true).Timestamp(TimeSpan.FromMilliseconds(700), PrecisionResolutionStrategy.Floor);
+
+            Assert.Equal("foo bar=t 1\nfoo bar=t 0", writer.ToString());
         }
     }
 }


### PR DESCRIPTION
Allows writing LineProtocol using timestamps at a precision other than nanoseconds.

Precision to use is set when creating the `LineProtocolWriter` as I needs to be consistent for the whole batch. The client will set the precision parameter when asked to send a batch with precision set to something other than nanoseconds.

By default if given a timestamp at a higher precision that write setup to write (e.g. with seconds defined when writing hours) an error will be thrown. This behavior can be configured when creating the writer and overridden when writing each individual point.
Instead of erroring the writer can be setup to floor, ceiling or round the timestamp.
