### PR TITLE
 Fixes #46 - adds pseudo high res timestamp generator. 

### DIFF
--- a/src/InfluxDB.Collector/MetricsCollector.cs
+++ b/src/InfluxDB.Collector/MetricsCollector.cs
@@ -7,8 +7,7 @@ namespace InfluxDB.Collector
 {
     public abstract class MetricsCollector : IPointEmitter, IDisposable
     {
-        private readonly Util.ITimestampSource _timestampSource = new Util.PseudoHighResTimestampSource();
-
+        readonly Util.ITimestampSource _timestampSource = new Util.PseudoHighResTimestampSource();
 
         public void Increment(string measurement, long count = 1, IReadOnlyDictionary<string, string> tags = null)
         {

--- a/src/InfluxDB.Collector/MetricsCollector.cs
+++ b/src/InfluxDB.Collector/MetricsCollector.cs
@@ -7,6 +7,9 @@ namespace InfluxDB.Collector
 {
     public abstract class MetricsCollector : IPointEmitter, IDisposable
     {
+        private readonly Util.ITimestampSource _timestampSource = new Util.PseudoHighResTimestampSource();
+
+
         public void Increment(string measurement, long count = 1, IReadOnlyDictionary<string, string> tags = null)
         {
             Write(measurement, new Dictionary<string, object> { { "count", count } }, tags);
@@ -38,7 +41,7 @@ namespace InfluxDB.Collector
         {
             try
             {
-                var point = new PointData(measurement, fields, tags, timestamp ?? DateTime.UtcNow);
+                var point = new PointData(measurement, fields, tags, timestamp ?? _timestampSource.GetUtcNow());
                 Emit(new[] { point });
             }
             catch (Exception ex)

--- a/src/InfluxDB.Collector/Util/ITimestampSource.cs
+++ b/src/InfluxDB.Collector/Util/ITimestampSource.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace InfluxDB.Collector.Util
+{
+    /// <summary>
+    /// Supplier of timestamps for metrics 
+    /// </summary>
+    internal interface ITimestampSource
+    {
+        DateTime GetUtcNow();
+    }
+}

--- a/src/InfluxDB.Collector/Util/ITimestampSource.cs
+++ b/src/InfluxDB.Collector/Util/ITimestampSource.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace InfluxDB.Collector.Util
 {

--- a/src/InfluxDB.Collector/Util/ITimestampSource.cs
+++ b/src/InfluxDB.Collector/Util/ITimestampSource.cs
@@ -5,7 +5,7 @@ namespace InfluxDB.Collector.Util
     /// <summary>
     /// Supplier of timestamps for metrics 
     /// </summary>
-    internal interface ITimestampSource
+    interface ITimestampSource
     {
         DateTime GetUtcNow();
     }

--- a/src/InfluxDB.Collector/Util/PseudoHighResTimestampSource.cs
+++ b/src/InfluxDB.Collector/Util/PseudoHighResTimestampSource.cs
@@ -45,11 +45,6 @@ namespace InfluxDB.Collector.Util
                     return utcNow;
                 }
             }
-
         }
-
-
     }
-
-
 }

--- a/src/InfluxDB.Collector/Util/PseudoHighResTimestampSource.cs
+++ b/src/InfluxDB.Collector/Util/PseudoHighResTimestampSource.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace InfluxDB.Collector.Util
 {

--- a/src/InfluxDB.Collector/Util/PseudoHighResTimestampSource.cs
+++ b/src/InfluxDB.Collector/Util/PseudoHighResTimestampSource.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace InfluxDB.Collector.Util
+{
+
+
+
+    /// <summary>
+    /// Implements <see cref="ITimestampSource"/>
+    /// in a way that combines the low-ish resolution DateTime.UtcNow
+    /// with a sequence number added to the ticks to provide 
+    /// pseudo-tick precision timestamps
+    /// </summary>
+    /// <remarks>
+    /// See https://github.com/influxdata/influxdb-csharp/issues/46 for why this is necessary.
+    /// Long story short: 
+    /// a) InfluxDB has a "LastWriteWins" policy for points that have the same timestamp and tags. 
+    /// b) The normal <see cref="System.DateTime.UtcNow"/> only supplies timestamps that change not as often as you think.
+    /// c) In a web server, it's entirely possible for more than one thread to get the same UtcNow value
+    /// 
+    /// As a remediation for this, we infuse DateTime.UtcNow with a sequence number until it ticks over.
+    /// 
+    /// </remarks>
+    public class PseudoHighResTimestampSource : ITimestampSource
+    {
+
+        private long _lastUtcNowTicks = 0;
+        private long _sequence = 0;
+        private readonly object lockObj = new object();
+
+       
+        public DateTime GetUtcNow()
+        {
+            DateTime utcNow = DateTime.UtcNow;
+
+            lock (lockObj)
+            {
+                if (utcNow.Ticks == _lastUtcNowTicks)
+                {
+                    // UtcNow hasn't rolled over yet, so 
+                    // add a sequence number to it
+                    _sequence++;
+                    long pseudoTicks = utcNow.Ticks + _sequence;
+                    return new DateTime(pseudoTicks, DateTimeKind.Utc);
+                }
+                else
+                {
+                    // Reset as UtcNow has rolled over
+                    _sequence = 0;
+                    _lastUtcNowTicks = utcNow.Ticks;
+                    return utcNow;
+                }
+            }
+
+        }
+
+
+    }
+
+
+}

--- a/src/InfluxDB.Collector/Util/PseudoHighResTimestampSource.cs
+++ b/src/InfluxDB.Collector/Util/PseudoHighResTimestampSource.cs
@@ -17,7 +17,7 @@ namespace InfluxDB.Collector.Util
     /// 
     /// As a remediation for this, we infuse DateTime.UtcNow with a sequence number until it ticks over.
     /// </remarks>
-    internal class PseudoHighResTimestampSource : ITimestampSource
+    class PseudoHighResTimestampSource : ITimestampSource
     {
         private long _lastUtcNowTicks = 0;
         private long _sequence = 0;

--- a/src/InfluxDB.Collector/Util/PseudoHighResTimestampSource.cs
+++ b/src/InfluxDB.Collector/Util/PseudoHighResTimestampSource.cs
@@ -2,9 +2,6 @@
 
 namespace InfluxDB.Collector.Util
 {
-
-
-
     /// <summary>
     /// Implements <see cref="ITimestampSource"/>
     /// in a way that combines the low-ish resolution DateTime.UtcNow
@@ -19,16 +16,13 @@ namespace InfluxDB.Collector.Util
     /// c) In a web server, it's entirely possible for more than one thread to get the same UtcNow value
     /// 
     /// As a remediation for this, we infuse DateTime.UtcNow with a sequence number until it ticks over.
-    /// 
     /// </remarks>
-    public class PseudoHighResTimestampSource : ITimestampSource
+    internal class PseudoHighResTimestampSource : ITimestampSource
     {
-
         private long _lastUtcNowTicks = 0;
         private long _sequence = 0;
         private readonly object lockObj = new object();
-
-       
+  
         public DateTime GetUtcNow()
         {
             DateTime utcNow = DateTime.UtcNow;

--- a/test/InfluxDB.LineProtocol.Tests/Collector/PseudoHighResTimestampSourceTests.cs
+++ b/test/InfluxDB.LineProtocol.Tests/Collector/PseudoHighResTimestampSourceTests.cs
@@ -61,7 +61,6 @@ namespace InfluxDB.LineProtocol.Tests.Collector.Util
 
             Assert.Equal(0, highResTotalCollisions);
             output.WriteLine($"No collisions detected with high resolution source, compared to {dateTimeCollisions} for DateTime.UtcNow.");
-
         }
 
         [Fact]
@@ -109,7 +108,6 @@ namespace InfluxDB.LineProtocol.Tests.Collector.Util
 
             Assert.Equal(0, highResTotalCollisions);
             output.WriteLine($"No collisions detected with high resolution source, compared to {dateTimeCollisions} for DateTime.UtcNow.");
-
         }
 
         [Fact]
@@ -119,7 +117,6 @@ namespace InfluxDB.LineProtocol.Tests.Collector.Util
 
             DateTime result = target.GetUtcNow();
             Assert.Equal(DateTimeKind.Utc, result.Kind);
-
         }
 
         [Fact]

--- a/test/InfluxDB.LineProtocol.Tests/Collector/PseudoHighResTimestampSourceTests.cs
+++ b/test/InfluxDB.LineProtocol.Tests/Collector/PseudoHighResTimestampSourceTests.cs
@@ -6,7 +6,6 @@ using InfluxDB.Collector.Util;
 
 namespace InfluxDB.LineProtocol.Tests.Collector.Util
 {
-
     public class PseudoHighResTimeStampSourceTests
     {
         private readonly ITestOutputHelper output;
@@ -16,18 +15,16 @@ namespace InfluxDB.LineProtocol.Tests.Collector.Util
             this.output = output;
         }
 
-
         [Fact]
         public void CanSupplyHighResTimestamps()
         {
-            const int ITERATIONS = 100000;
-
+            const int iterations = 100000;
 
             // Even if we call inside a very tight loop, 
             // we should get better (pseudo) resolution than just DateTime.UtcNow
             long dateTimeCollisions = 0;
             DateTime previousDateTime = DateTime.UtcNow;
-            for (int i = 0; i < ITERATIONS; i++)
+            for (int i = 0; i < iterations; i++)
             {
                 // Attempt with date time directly
                 var current = DateTime.UtcNow;
@@ -38,8 +35,7 @@ namespace InfluxDB.LineProtocol.Tests.Collector.Util
                 }
                 previousDateTime = current;
             }
-
-
+            
             if (0 == dateTimeCollisions)
             {
                 // Warn because we do expect that datetime.now has collisions in such a tight loop
@@ -51,7 +47,7 @@ namespace InfluxDB.LineProtocol.Tests.Collector.Util
             var target = new PseudoHighResTimestampSource();
             long highResTotalCollisions = 0;
             previousDateTime = target.GetUtcNow();
-            for (int i = 0; i < ITERATIONS; i++)
+            for (int i = 0; i < iterations; i++)
             {
                 // Attempt with date time directly
                 var current = target.GetUtcNow();
@@ -71,12 +67,12 @@ namespace InfluxDB.LineProtocol.Tests.Collector.Util
         [Fact]
         public void CanSupplyHighResTimestampsInParallel()
         {
-            const int ITERATIONS = 100000;
+            const int iterations = 100000;
 
             // Even if we call inside a very tight loop, we should get better (pseudo) resolution than just DateTime.UtcNow
             int dateTimeCollisions = 0;
             DateTime previousDateTime = DateTime.UtcNow;
-            Parallel.For(0, ITERATIONS, (i) => // (int i = 0; i < 100000; i++)
+            Parallel.For(0, iterations, (i) => // (int i = 0; i < 100000; i++)
             {
                 // Attempt with date time directly
                 var current = DateTime.UtcNow;
@@ -99,7 +95,7 @@ namespace InfluxDB.LineProtocol.Tests.Collector.Util
             var target = new PseudoHighResTimestampSource();
             int highResTotalCollisions = 0;
             previousDateTime = target.GetUtcNow();
-            Parallel.For(0, ITERATIONS, (i) => // (int i = 0; i < 100000; i++)
+            Parallel.For(0, iterations, (i) => // (int i = 0; i < 100000; i++)
             {
                 // Attempt with date time directly
                 var current = target.GetUtcNow();
@@ -115,7 +111,6 @@ namespace InfluxDB.LineProtocol.Tests.Collector.Util
             output.WriteLine($"No collisions detected with high resolution source, compared to {dateTimeCollisions} for DateTime.UtcNow.");
 
         }
-
 
         [Fact]
         public void WillGiveUtcDateTimeKind()
@@ -135,15 +130,15 @@ namespace InfluxDB.LineProtocol.Tests.Collector.Util
 
             // Average over 10000 iterations and get the average drift
             decimal totalDrift = 0;
-            const int ITERATIONS = 10000;
-            for (int i = 0; i < ITERATIONS; i++)
+            const int iterations = 10000;
+            for (int i = 0; i < iterations; i++)
             {
                 DateTime current = DateTime.UtcNow;
                 DateTime result = target.GetUtcNow();
 
                 totalDrift += Convert.ToDecimal((result - current).TotalMilliseconds);
             }
-            var averageDrift = totalDrift / ITERATIONS;
+            var averageDrift = totalDrift / iterations;
 
             if (averageDrift > MAX_DRIFT_MS)
             {
@@ -152,11 +147,9 @@ namespace InfluxDB.LineProtocol.Tests.Collector.Util
             }
             else
             {
-                output.WriteLine ($"Total Drift over {ITERATIONS} iterations: {totalDrift}ms. Average {averageDrift}ms");
+                output.WriteLine ($"Total Drift over {iterations} iterations: {totalDrift}ms. Average {averageDrift}ms");
             }
-
         }
-
     }
 }
 

--- a/test/InfluxDB.LineProtocol.Tests/Collector/PseudoHighResTimestampSourceTests.cs
+++ b/test/InfluxDB.LineProtocol.Tests/Collector/PseudoHighResTimestampSourceTests.cs
@@ -1,0 +1,163 @@
+﻿using System;
+using Xunit;
+using System.Threading.Tasks;
+using Xunit.Abstractions;
+using InfluxDB.Collector.Util;
+
+namespace InfluxDB.LineProtocol.Tests.Collector.Util
+{
+
+    public class PseudoHighResTimeStampSourceTests
+    {
+        private readonly ITestOutputHelper output;
+
+        public PseudoHighResTimeStampSourceTests(ITestOutputHelper output)
+        {
+            this.output = output;
+        }
+
+
+        [Fact]
+        public void CanSupplyHighResTimestamps()
+        {
+            const int ITERATIONS = 100000;
+
+
+            // Even if we call inside a very tight loop, 
+            // we should get better (pseudo) resolution than just DateTime.UtcNow
+            long dateTimeCollisions = 0;
+            DateTime previousDateTime = DateTime.UtcNow;
+            for (int i = 0; i < ITERATIONS; i++)
+            {
+                // Attempt with date time directly
+                var current = DateTime.UtcNow;
+
+                if (previousDateTime == current)
+                {
+                    dateTimeCollisions++;
+                }
+                previousDateTime = current;
+            }
+
+
+            if (0 == dateTimeCollisions)
+            {
+                // Warn because we do expect that datetime.now has collisions in such a tight loop
+                output.WriteLine("Warning! Expected DateTime.UtcNow to have some collisions, but seemed to be high resolution already.");
+            }
+
+            // Now attempt to use our pseudo high precision provider that includes a sequence number to ensure that it 
+            // never collides
+            var target = new PseudoHighResTimestampSource();
+            long highResTotalCollisions = 0;
+            previousDateTime = target.GetUtcNow();
+            for (int i = 0; i < ITERATIONS; i++)
+            {
+                // Attempt with date time directly
+                var current = target.GetUtcNow();
+
+                if (previousDateTime == current)
+                {
+                    highResTotalCollisions++;
+                }
+                previousDateTime = current;
+            }
+
+            Assert.Equal(0, highResTotalCollisions);
+            output.WriteLine($"No collisions detected with high resolution source, compared to {dateTimeCollisions} for DateTime.UtcNow.");
+
+        }
+
+        [Fact]
+        public void CanSupplyHighResTimestampsInParallel()
+        {
+            const int ITERATIONS = 100000;
+
+            // Even if we call inside a very tight loop, we should get better (pseudo) resolution than just DateTime.UtcNow
+            int dateTimeCollisions = 0;
+            DateTime previousDateTime = DateTime.UtcNow;
+            Parallel.For(0, ITERATIONS, (i) => // (int i = 0; i < 100000; i++)
+            {
+                // Attempt with date time directly
+                var current = DateTime.UtcNow;
+
+                if (previousDateTime == current)
+                {
+                    System.Threading.Interlocked.Increment(ref dateTimeCollisions);
+                }
+                previousDateTime = current;
+            });
+
+            if (0 == dateTimeCollisions)
+            {
+                // Warn because we do expect that datetime.now has collisions in such a tight loop
+                output.WriteLine("Warning! Expected DateTime.UtcNow to have some collisions, but seemed to be high resolution already.");
+            }
+
+            // Now attempt to use our pseudo high precision provider that includes a sequence number to ensure that it 
+            // never collides
+            var target = new PseudoHighResTimestampSource();
+            int highResTotalCollisions = 0;
+            previousDateTime = target.GetUtcNow();
+            Parallel.For(0, ITERATIONS, (i) => // (int i = 0; i < 100000; i++)
+            {
+                // Attempt with date time directly
+                var current = target.GetUtcNow();
+
+                if (previousDateTime == current)
+                {
+                    System.Threading.Interlocked.Increment(ref highResTotalCollisions);
+                }
+                previousDateTime = current;
+            });
+
+            Assert.Equal(0, highResTotalCollisions);
+            output.WriteLine($"No collisions detected with high resolution source, compared to {dateTimeCollisions} for DateTime.UtcNow.");
+
+        }
+
+
+        [Fact]
+        public void WillGiveUtcDateTimeKind()
+        {
+            var target = new PseudoHighResTimestampSource();
+
+            DateTime result = target.GetUtcNow();
+            Assert.Equal(DateTimeKind.Utc, result.Kind);
+
+        }
+
+        [Fact]
+        public void WillNotDriftTooFarFromUtcNow()
+        {
+            var target = new PseudoHighResTimestampSource();
+            const int MAX_DRIFT_MS = 10;
+
+            // Average over 10000 iterations and get the average drift
+            decimal totalDrift = 0;
+            const int ITERATIONS = 10000;
+            for (int i = 0; i < ITERATIONS; i++)
+            {
+                DateTime current = DateTime.UtcNow;
+                DateTime result = target.GetUtcNow();
+
+                totalDrift += Convert.ToDecimal((result - current).TotalMilliseconds);
+            }
+            var averageDrift = totalDrift / ITERATIONS;
+
+            if (averageDrift > MAX_DRIFT_MS)
+            {
+                output.WriteLine($"Expected times were more than {MAX_DRIFT_MS}ms apart. Instead they were {averageDrift}ms apart.");
+                Assert.True(false); // Force fail.
+            }
+            else
+            {
+                output.WriteLine ($"Total Drift over {ITERATIONS} iterations: {totalDrift}ms. Average {averageDrift}ms");
+            }
+
+        }
+
+    }
+}
+
+

--- a/test/InfluxDB.LineProtocol.Tests/Collector/PseudoHighResTimestampSourceTests.cs
+++ b/test/InfluxDB.LineProtocol.Tests/Collector/PseudoHighResTimestampSourceTests.cs
@@ -27,7 +27,7 @@ namespace InfluxDB.LineProtocol.Tests.Collector.Util
             for (int i = 0; i < iterations; i++)
             {
                 // Attempt with date time directly
-                var current = DateTime.UtcNow;
+                DateTime current = DateTime.UtcNow;
 
                 if (previousDateTime == current)
                 {
@@ -44,13 +44,13 @@ namespace InfluxDB.LineProtocol.Tests.Collector.Util
 
             // Now attempt to use our pseudo high precision provider that includes a sequence number to ensure that it 
             // never collides
-            var target = new PseudoHighResTimestampSource();
+            ITimestampSource target = new PseudoHighResTimestampSource();
             long highResTotalCollisions = 0;
             previousDateTime = target.GetUtcNow();
             for (int i = 0; i < iterations; i++)
             {
                 // Attempt with date time directly
-                var current = target.GetUtcNow();
+                DateTime current = target.GetUtcNow();
 
                 if (previousDateTime == current)
                 {
@@ -75,7 +75,7 @@ namespace InfluxDB.LineProtocol.Tests.Collector.Util
             Parallel.For(0, iterations, (i) => // (int i = 0; i < 100000; i++)
             {
                 // Attempt with date time directly
-                var current = DateTime.UtcNow;
+                DateTime current = DateTime.UtcNow;
 
                 if (previousDateTime == current)
                 {
@@ -92,13 +92,13 @@ namespace InfluxDB.LineProtocol.Tests.Collector.Util
 
             // Now attempt to use our pseudo high precision provider that includes a sequence number to ensure that it 
             // never collides
-            var target = new PseudoHighResTimestampSource();
+            ITimestampSource target = new PseudoHighResTimestampSource();
             int highResTotalCollisions = 0;
             previousDateTime = target.GetUtcNow();
             Parallel.For(0, iterations, (i) => // (int i = 0; i < 100000; i++)
             {
                 // Attempt with date time directly
-                var current = target.GetUtcNow();
+                DateTime current = target.GetUtcNow();
 
                 if (previousDateTime == current)
                 {
@@ -115,7 +115,7 @@ namespace InfluxDB.LineProtocol.Tests.Collector.Util
         [Fact]
         public void WillGiveUtcDateTimeKind()
         {
-            var target = new PseudoHighResTimestampSource();
+            ITimestampSource target = new PseudoHighResTimestampSource();
 
             DateTime result = target.GetUtcNow();
             Assert.Equal(DateTimeKind.Utc, result.Kind);
@@ -125,7 +125,7 @@ namespace InfluxDB.LineProtocol.Tests.Collector.Util
         [Fact]
         public void WillNotDriftTooFarFromUtcNow()
         {
-            var target = new PseudoHighResTimestampSource();
+            ITimestampSource target = new PseudoHighResTimestampSource();
             const int MAX_DRIFT_MS = 10;
 
             // Average over 10000 iterations and get the average drift
@@ -138,7 +138,7 @@ namespace InfluxDB.LineProtocol.Tests.Collector.Util
 
                 totalDrift += Convert.ToDecimal((result - current).TotalMilliseconds);
             }
-            var averageDrift = totalDrift / iterations;
+            Decimal averageDrift = totalDrift / iterations;
 
             if (averageDrift > MAX_DRIFT_MS)
             {


### PR DESCRIPTION
This adds a utility to generate timestamps from `DateTime.UtcNow + a sequential tick.` This will get around the issue where `DateTime.UtcNow` may not update frequently enough for it to be used in multitheaded environments when combined with InfluxDB's default policy of last write wins for the same timestamp/tags. Only applies if the caller doesn't supply a timestamp. 

As stated in #46, there is no easy solution to this, but a sequential timestamp should make the "out of the box" experience safer. If there are better ways to solve this, or improved ways to implement this, I'm happy to help.