### PR TITLE
Added RetentionPolicy and Precision

### DIFF
--- a/src/InfluxDB.LineProtocol/Client/LineProtocolClient.cs
+++ b/src/InfluxDB.LineProtocol/Client/LineProtocolClient.cs
@@ -35,7 +35,7 @@ namespace InfluxDB.LineProtocol.Client
         {
             var stringWriter = new StringWriter();
 
-            payload.Format(stringWriter);
+            payload.Format(stringWriter, precision);
 
             return SendAsync(stringWriter.ToString(), precision, cancellationToken);
         }

--- a/src/InfluxDB.LineProtocol/Client/LineProtocolClient.cs
+++ b/src/InfluxDB.LineProtocol/Client/LineProtocolClient.cs
@@ -31,13 +31,13 @@ namespace InfluxDB.LineProtocol.Client
             _password = password;
         }
 
-        public Task<LineProtocolWriteResult> WriteAsync(LineProtocolPayload payload, CancellationToken cancellationToken = default(CancellationToken))
+        public Task<LineProtocolWriteResult> WriteAsync(LineProtocolPayload payload, Precision precision = Precision.Nanoseconds, CancellationToken cancellationToken = default(CancellationToken))
         {
             var stringWriter = new StringWriter();
 
             payload.Format(stringWriter);
 
-            return SendAsync(stringWriter.ToString(), Precision.Nanoseconds, cancellationToken);
+            return SendAsync(stringWriter.ToString(), precision, cancellationToken);
         }
 
         public Task<LineProtocolWriteResult> SendAsync(LineProtocolWriter lineProtocolWriter, CancellationToken cancellationToken = default(CancellationToken))

--- a/src/InfluxDB.LineProtocol/Payload/LineProtocolPayload.cs
+++ b/src/InfluxDB.LineProtocol/Payload/LineProtocolPayload.cs
@@ -14,13 +14,13 @@ namespace InfluxDB.LineProtocol.Payload
             _points.Add(point);
         }
 
-        public void Format(TextWriter textWriter)
+        public void Format(TextWriter textWriter, Precision precision)
         {
             if (textWriter == null) throw new ArgumentNullException(nameof(textWriter));
 
             foreach (var point in _points)
             {
-                point.Format(textWriter);
+                point.Format(textWriter, precision);
                 textWriter.Write('\n');
             }
         }

--- a/src/InfluxDB.LineProtocol/Payload/LineProtocolPoint.cs
+++ b/src/InfluxDB.LineProtocol/Payload/LineProtocolPoint.cs
@@ -37,7 +37,7 @@ namespace InfluxDB.LineProtocol.Payload
             UtcTimestamp = utcTimestamp;
         }
 
-        public void Format(TextWriter textWriter)
+        public void Format(TextWriter textWriter, Precision precision)
         {
             if (textWriter == null) throw new ArgumentNullException(nameof(textWriter));
 
@@ -47,7 +47,7 @@ namespace InfluxDB.LineProtocol.Payload
             {
                 foreach (var t in Tags.OrderBy(t => t.Key))
                 {
-                    if (t.Value == null || t.Value == "")
+                    if (string.IsNullOrEmpty(t.Value))
                         continue;
 
                     textWriter.Write(',');
@@ -70,9 +70,8 @@ namespace InfluxDB.LineProtocol.Payload
             if (UtcTimestamp != null)
             {
                 textWriter.Write(' ');
-                textWriter.Write(LineProtocolSyntax.FormatTimestamp(UtcTimestamp.Value));
+                textWriter.Write(LineProtocolSyntax.FormatTimestamp(UtcTimestamp.Value, precision));
             }
         }
     }
 }
-

--- a/src/InfluxDB.LineProtocol/Payload/LineProtocolSyntax.cs
+++ b/src/InfluxDB.LineProtocol/Payload/LineProtocolSyntax.cs
@@ -60,7 +60,7 @@ namespace InfluxDB.LineProtocol.Payload
 
         static string FormatBoolean(object b)
         {
-            return ((bool)b) ? "t" : "f";
+            return (bool)b ? "t" : "f";
         }
 
         static string FormatString(string s)
@@ -68,10 +68,26 @@ namespace InfluxDB.LineProtocol.Payload
             return "\"" + s.Replace("\"", "\\\"") + "\"";
         }
 
-        public static string FormatTimestamp(DateTime utcTimestamp)
+        public static string FormatTimestamp(DateTime utcTimestamp, Precision precision)
         {
-            var t = utcTimestamp - Origin;
-            return (t.Ticks * 100L).ToString(CultureInfo.InvariantCulture);
+            TimeSpan ts = utcTimestamp - Origin;
+            switch (precision)
+            {
+                case Precision.Nanoseconds:
+                    return (ts.Ticks * 100).ToString(CultureInfo.InvariantCulture);
+                case Precision.Microseconds:
+                    return (ts.Ticks / 10).ToString(CultureInfo.InvariantCulture);
+                case Precision.Milliseconds:
+                    return ((long)ts.TotalMilliseconds).ToString(CultureInfo.InvariantCulture);
+                case Precision.Seconds:
+                    return ((long)ts.TotalSeconds).ToString(CultureInfo.InvariantCulture);
+                case Precision.Minutes:
+                    return ((long)ts.TotalMinutes).ToString(CultureInfo.InvariantCulture);
+                case Precision.Hours:
+                    return ((long)ts.TotalHours).ToString(CultureInfo.InvariantCulture);
+                default:
+                    throw new NotSupportedException("Precision is unknown to the formatter.");
+            }
         }
     }
 }

--- a/test/InfluxDB.LineProtocol.Tests/Client/MockLineProtocolClient.cs
+++ b/test/InfluxDB.LineProtocol.Tests/Client/MockLineProtocolClient.cs
@@ -11,7 +11,7 @@ namespace InfluxDB.LineProtocol.Tests.Client
         {
         }
 
-        private MockLineProtocolClient(MockHttpMessageHandler handler, Uri serverBaseAddress, string database) : base(handler, serverBaseAddress, database, null, null)
+        private MockLineProtocolClient(MockHttpMessageHandler handler, Uri serverBaseAddress, string database) : base(handler, serverBaseAddress, database, null, null, null)
         {
             Handler = handler;
             BaseAddress = serverBaseAddress;


### PR DESCRIPTION
Retention policy needs to be specified for uploads to non-default retention policy.
Seconds precision is generally used for IT infrastructure monitoring and uploading nanoseconds adds significant overhead for InfluxDB.