### PR TITLE
Basic Changes and Move to .NET Standard 2.0 / Framework 4.6.1

### DIFF
--- a/influxdb-csharp.sln
+++ b/influxdb-csharp.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26730.3
+VisualStudioVersion = 15.0.27130.2036
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{72DC28B9-37B5-425C-8532-5CA91D253A70}"
 EndProject
@@ -31,6 +31,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "InfluxDB.Collector", "src\I
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Benchmark", "sample\Benchmark\Benchmark.csproj", "{2A34EE83-FB59-4A41-8BB5-174BE678533E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InfluxDb.UdpSupport.ConsoleTest", "test\Consoles\InfluxDb.UdpSupport.ConsoleTest\InfluxDb.UdpSupport.ConsoleTest.csproj", "{1B138F1D-A772-4656-9142-442DEFB969E5}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sample-UDP-Support", "sample\Sample-UDP-Support\Sample-UDP-Support.csproj", "{62A1A1E7-CCF5-49D9-B462-F11EEF7F5591}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -57,6 +61,14 @@ Global
 		{2A34EE83-FB59-4A41-8BB5-174BE678533E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2A34EE83-FB59-4A41-8BB5-174BE678533E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2A34EE83-FB59-4A41-8BB5-174BE678533E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1B138F1D-A772-4656-9142-442DEFB969E5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1B138F1D-A772-4656-9142-442DEFB969E5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1B138F1D-A772-4656-9142-442DEFB969E5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1B138F1D-A772-4656-9142-442DEFB969E5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{62A1A1E7-CCF5-49D9-B462-F11EEF7F5591}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{62A1A1E7-CCF5-49D9-B462-F11EEF7F5591}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{62A1A1E7-CCF5-49D9-B462-F11EEF7F5591}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{62A1A1E7-CCF5-49D9-B462-F11EEF7F5591}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -67,6 +79,8 @@ Global
 		{DC6028D6-ED1D-4857-B5EB-28BA05E3F531} = {CD65EE64-FDA8-4ED9-A7F2-81BDD9F64C64}
 		{F690F3E3-D9F0-441A-9E70-4F70998BDD1B} = {72DC28B9-37B5-425C-8532-5CA91D253A70}
 		{2A34EE83-FB59-4A41-8BB5-174BE678533E} = {CD65EE64-FDA8-4ED9-A7F2-81BDD9F64C64}
+		{1B138F1D-A772-4656-9142-442DEFB969E5} = {75C71D21-E6FD-493F-A355-997EEF4DDF11}
+		{62A1A1E7-CCF5-49D9-B462-F11EEF7F5591} = {CD65EE64-FDA8-4ED9-A7F2-81BDD9F64C64}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {AB0C6BCE-235A-4018-8644-7652EC826FF5}

--- a/sample/Benchmark/Benchmark.csproj
+++ b/sample/Benchmark/Benchmark.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net46</TargetFrameworks>
+    <TargetFrameworks>net461</TargetFrameworks>
     <AssemblyName>Sample</AssemblyName>
     <PackageId>Sample</PackageId>
     <ApplicationIcon />
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.10.9" />
-    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.10.9" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.10.12" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.10.12" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sample/Sample-UDP-Support/App.config
+++ b/sample/Sample-UDP-Support/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
+    </startup>
+</configuration>

--- a/sample/Sample-UDP-Support/Program.cs
+++ b/sample/Sample-UDP-Support/Program.cs
@@ -1,0 +1,73 @@
+﻿using InfluxDB.Collector;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Threading.Tasks;
+
+// influx-db command line:
+// start with
+// # influx
+// # show databases
+// # CREATE DATABASE {name}
+// # DROP DATABASE {name}
+// # precision rfc3339
+// # use <database>
+// # SHOW MEASUREMENTS
+// # SHOW MEASUREMENTS WITH MEASUREMENT =~ /v1\..*/ -- all fields from measurements that start with 'v1.' 
+// # SHOW SERIES
+// # SHOW SERIES [FROM <measurement_name> [WHERE <tag_key>='<tag_value>']]
+// # DROP SERIES FROM /v1.*\.end/
+// # SHOW TAG KEYS
+// # SHOW TAG KEYS FROM "v1.cos"
+// # SHOW FIELD KEYS
+// # SHOW FIELD KEYS FROM /v1\..*\.sin/   -- all fields from series that start with 'v1.' and end with '.sin'
+
+/*
+# influx
+docker run --name influx -p 8086:8086 -p 8089:8089/udp -p 8088:8088 -v C:\Docker\Volumes\influxdb\db:/var/lib/influxdb -v C:\Docker\Volumes\influxdb\config\influxdb.conf:/etc/influxdb/influxdb.conf:ro influxdb -config /etc/influxdb/influxdb.conf
+docker run -d -p 8083:8083 -p 8086:8086 -p 8089:4444/udp --expose 8083 --expose 8086 --expose 4444 -e UDP_DB="playground" tutum/influxdb
+
+*/
+namespace Sample
+{
+    public static class Program
+    {
+        public static void Main(string[] args)
+        {
+            Collect().Wait();
+
+            Console.ReadKey();
+        }
+
+        async static Task Collect()
+        {
+            var process = Process.GetCurrentProcess();
+
+            Metrics.Collector = new CollectorConfiguration()
+                .Tag.With("host", Environment.GetEnvironmentVariable("COMPUTERNAME"))
+                .Tag.With("os", Environment.GetEnvironmentVariable("OS"))
+                .Tag.With("process", Path.GetFileName(process.MainModule.FileName))
+                .Batch.AtInterval(TimeSpan.FromSeconds(2))
+                //.WriteTo.InfluxDB("http://localhost:8086", "data")
+                .WriteTo.InfluxDB("udp://localhost:8089", "data")
+                .CreateCollector();
+
+            while (true)
+            {
+                Metrics.Increment("iterations");
+
+                Metrics.Write("cpu_time",
+                    new Dictionary<string, object>
+                    {
+                        { "value", process.TotalProcessorTime.TotalMilliseconds },
+                        { "user", process.UserProcessorTime.TotalMilliseconds }
+                    });
+
+                Metrics.Measure("working_set", process.WorkingSet64);
+
+                await Task.Delay(1000);
+            }
+        }
+    }
+}

--- a/sample/Sample-UDP-Support/Properties/AssemblyInfo.cs
+++ b/sample/Sample-UDP-Support/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Sample-UDP-Support")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Sample-UDP-Support")]
+[assembly: AssemblyCopyright("Copyright ©  2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("62a1a1e7-ccf5-49d9-b462-f11eef7f5591")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/sample/Sample-UDP-Support/Sample-UDP-Support.csproj
+++ b/sample/Sample-UDP-Support/Sample-UDP-Support.csproj
@@ -1,0 +1,63 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{62A1A1E7-CCF5-49D9-B462-F11EEF7F5591}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>Sample_UDP_Support</RootNamespace>
+    <AssemblyName>Sample-UDP-Support</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\InfluxDB.Collector\InfluxDB.Collector.csproj">
+      <Project>{f690f3e3-d9f0-441a-9e70-4f70998bdd1b}</Project>
+      <Name>InfluxDB.Collector</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\InfluxDB.LineProtocol\InfluxDB.LineProtocol.csproj">
+      <Project>{069e0ac5-a2cf-4584-89a7-f475276e244c}</Project>
+      <Name>InfluxDB.LineProtocol</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/sample/Sample-UDP-Support/packages.config
+++ b/sample/Sample-UDP-Support/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="System.Threading" version="4.3.0" targetFramework="net461" />
+</packages>

--- a/sample/Sample/Sample.csproj
+++ b/sample/Sample/Sample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;netcoreapp1.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
     <AssemblyName>Sample</AssemblyName>
     <PackageId>Sample</PackageId>
   </PropertyGroup>

--- a/src/InfluxDB.Collector/Configuration/PipelinedCollectorEmitConfiguration.cs
+++ b/src/InfluxDB.Collector/Configuration/PipelinedCollectorEmitConfiguration.cs
@@ -11,9 +11,10 @@ namespace InfluxDB.Collector.Configuration
     {
         readonly CollectorConfiguration _configuration;
         readonly List<Action<PointData[]>> _emitters = new List<Action<PointData[]>>();
-        LineProtocolClient _client;
+        private ILineProtocolClient _client;
 
-        public PipelinedCollectorEmitConfiguration(CollectorConfiguration configuration)
+        public PipelinedCollectorEmitConfiguration(
+            CollectorConfiguration configuration)
         {
             if (configuration == null) throw new ArgumentNullException(nameof(configuration));
             _configuration = configuration;
@@ -21,7 +22,10 @@ namespace InfluxDB.Collector.Configuration
 
         public override CollectorConfiguration InfluxDB(Uri serverBaseAddress, string database, string username = null, string password = null)
         {
-            _client = new LineProtocolClient(serverBaseAddress, database, username, password);
+            if (string.Compare(serverBaseAddress.Scheme, "udp", ignoreCase: true) == 0)
+                _client = new LineProtocolUdpClient(serverBaseAddress, database, username, password);
+            else
+                _client = new LineProtocolClient(serverBaseAddress, database, username, password);
             return _configuration;
         }
 

--- a/src/InfluxDB.Collector/InfluxDB.Collector.csproj
+++ b/src/InfluxDB.Collector/InfluxDB.Collector.csproj
@@ -18,13 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Net.Sockets" Version="4.3.0" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\InfluxDB.LineProtocol\InfluxDB.LineProtocol.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Collections" Version="4.3.0" />
     <PackageReference Include="System.Linq" Version="4.3.0" />
     <PackageReference Include="System.Threading" Version="4.3.0" />

--- a/src/InfluxDB.Collector/InfluxDB.Collector.csproj
+++ b/src/InfluxDB.Collector/InfluxDB.Collector.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>A minimal metrics collection API for InfluxDB</Description>
     <Authors>influxdb-csharp Contributors</Authors>
-    <TargetFrameworks>net45;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>InfluxDB.Collector</AssemblyName>
     <VersionPrefix>1.1.1</VersionPrefix>
@@ -17,22 +17,21 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Net.Sockets" Version="4.3.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\InfluxDB.LineProtocol\InfluxDB.LineProtocol.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-    <PackageReference Include="System.Collections" Version="4.0.11" />
-    <PackageReference Include="System.Linq" Version="4.1.0" />
-    <PackageReference Include="System.Threading" Version="4.0.11" />
-    <PackageReference Include="System.Runtime" Version="4.1.0" />
-    <PackageReference Include="System.Net.Http" Version="4.1.1" />
-    <PackageReference Include="System.Console" Version="4.0.0" />
-    <PackageReference Include="System.Runtime.Extensions" Version="4.1.0" />
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="System.Collections" Version="4.3.0" />
+    <PackageReference Include="System.Linq" Version="4.3.0" />
+    <PackageReference Include="System.Threading" Version="4.3.0" />
+    <PackageReference Include="System.Runtime" Version="4.3.0" />
+    <PackageReference Include="System.Net.Http" Version="4.3.3" />
+    <PackageReference Include="System.Console" Version="4.3.0" />
+    <PackageReference Include="System.Runtime.Extensions" Version="4.3.0" />
   </ItemGroup>
 
 </Project>

--- a/src/InfluxDB.Collector/Pipeline/Emit/HttpLineProtocolEmitter.cs
+++ b/src/InfluxDB.Collector/Pipeline/Emit/HttpLineProtocolEmitter.cs
@@ -7,9 +7,9 @@ namespace InfluxDB.Collector.Pipeline.Emit
 {
     class HttpLineProtocolEmitter : IDisposable, IPointEmitter
     {
-        readonly LineProtocolClient _client;
+        readonly ILineProtocolClient _client;
 
-        public HttpLineProtocolEmitter(LineProtocolClient client)
+        public HttpLineProtocolEmitter(ILineProtocolClient client)
         {
             if (client == null) throw new ArgumentNullException(nameof(client));
             _client = client;

--- a/src/InfluxDB.LineProtocol/Client/ILineProtocolClient.cs
+++ b/src/InfluxDB.LineProtocol/Client/ILineProtocolClient.cs
@@ -1,0 +1,16 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using InfluxDB.LineProtocol.Payload;
+
+namespace InfluxDB.LineProtocol.Client
+{
+    public interface ILineProtocolClient
+    {
+        Task<LineProtocolWriteResult> SendAsync(
+            LineProtocolWriter lineProtocolWriter,
+            CancellationToken cancellationToken = default(CancellationToken));
+        Task<LineProtocolWriteResult> WriteAsync(
+            LineProtocolPayload payload, 
+            CancellationToken cancellationToken = default(CancellationToken));
+    }
+}

--- a/src/InfluxDB.LineProtocol/Client/LineProtocolClientBase.cs
+++ b/src/InfluxDB.LineProtocol/Client/LineProtocolClientBase.cs
@@ -1,0 +1,49 @@
+﻿using InfluxDB.LineProtocol.Payload;
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace InfluxDB.LineProtocol.Client
+{
+    public abstract class LineProtocolClientBase : ILineProtocolClient
+    {
+        protected readonly string _database, _username, _password;
+
+        protected LineProtocolClientBase(Uri serverBaseAddress, string database, string username, string password)
+        {
+            if (serverBaseAddress == null)
+                throw new ArgumentNullException(nameof(serverBaseAddress));
+            if (string.IsNullOrEmpty(database))
+                throw new ArgumentException("A database must be specified");
+
+            // Overload that allows injecting handler is protected to avoid HttpMessageHandler being part of our public api which would force clients to reference System.Net.Http when using the lib.
+            _database = database;
+            _username = username;
+            _password = password;
+        }
+
+        public Task<LineProtocolWriteResult> WriteAsync(LineProtocolPayload payload, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var stringWriter = new StringWriter();
+
+            payload.Format(stringWriter);
+
+            return OnSendAsync(stringWriter.ToString(), Precision.Nanoseconds, cancellationToken);
+        }
+
+        public Task<LineProtocolWriteResult> SendAsync(LineProtocolWriter lineProtocolWriter, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return OnSendAsync(lineProtocolWriter.ToString(), lineProtocolWriter.Precision, cancellationToken);
+        }
+
+        protected abstract Task<LineProtocolWriteResult> OnSendAsync(
+            string payload,
+            Precision precision,
+            CancellationToken cancellationToken = default(CancellationToken));
+    }
+}

--- a/src/InfluxDB.LineProtocol/Client/LineProtocolUdpClient.cs
+++ b/src/InfluxDB.LineProtocol/Client/LineProtocolUdpClient.cs
@@ -10,18 +10,18 @@ using System.Threading.Tasks;
 
 namespace InfluxDB.LineProtocol.Client
 {
-    public class LineProtocolUdpClient : ILineProtocolClient
+    public class LineProtocolUdpClient : LineProtocolClientBase
     {
         private readonly UdpClient _udpClient;
         private readonly string _udpHostName;
         private readonly int _udpPort;
-        private readonly string _database, _username, _password;
 
         public LineProtocolUdpClient(
-            Uri serverBaseAddress,
-            string database,
-            string username = null,
-            string password = null)
+                        Uri serverBaseAddress,
+                        string database,
+                        string username = null,
+                        string password = null)
+            :base(serverBaseAddress, database, username, password)
         {
             if (serverBaseAddress == null)
                 throw new ArgumentNullException(nameof(serverBaseAddress));
@@ -31,52 +31,13 @@ namespace InfluxDB.LineProtocol.Client
             _udpHostName = serverBaseAddress.Host;
             _udpPort = serverBaseAddress.Port;
             _udpClient = new UdpClient();
-            _database = database;
-            _username = username;
-            _password = password;
         }
 
-        public Task<LineProtocolWriteResult> WriteAsync(LineProtocolPayload payload, CancellationToken cancellationToken = default(CancellationToken))
+        protected override async Task<LineProtocolWriteResult> OnSendAsync(
+                                    string payload,
+                                    Precision precision,
+                                    CancellationToken cancellationToken = default(CancellationToken))
         {
-            var stringWriter = new StringWriter();
-
-            payload.Format(stringWriter);
-
-            return SendAsync(stringWriter.ToString(), Precision.Nanoseconds, cancellationToken);
-        }
-
-        public Task<LineProtocolWriteResult> SendAsync(LineProtocolWriter lineProtocolWriter, CancellationToken cancellationToken = default(CancellationToken))
-        {
-            return SendAsync(lineProtocolWriter.ToString(), lineProtocolWriter.Precision, cancellationToken);
-        }
-
-        private async Task<LineProtocolWriteResult> SendAsync(string payload, Precision precision, CancellationToken cancellationToken = default(CancellationToken))
-        {
-            var endpoint = $"write?db={Uri.EscapeDataString(_database)}";
-            if (!string.IsNullOrEmpty(_username))
-                endpoint += $"&u={Uri.EscapeDataString(_username)}&p={Uri.EscapeDataString(_password)}";
-
-            switch (precision)
-            {
-                case Precision.Microseconds:
-                    endpoint += "&precision=u";
-                    break;
-                case Precision.Milliseconds:
-                    endpoint += "&precision=ms";
-                    break;
-                case Precision.Seconds:
-                    endpoint += "&precision=s";
-                    break;
-                case Precision.Minutes:
-                    endpoint += "&precision=m";
-                    break;
-                case Precision.Hours:
-                    endpoint += "&precision=h";
-                    break;
-            }
-
-            var content = new StringContent(payload, Encoding.UTF8);
-
             var buffer = Encoding.UTF8.GetBytes(payload);
             int len = await _udpClient.SendAsync(buffer, buffer.Length, _udpHostName, _udpPort);
             return new LineProtocolWriteResult(len == buffer.Length, null);

--- a/src/InfluxDB.LineProtocol/InfluxDB.LineProtocol.csproj
+++ b/src/InfluxDB.LineProtocol/InfluxDB.LineProtocol.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>A .NET library for efficiently sending time series to InfluxDB</Description>
     <Authors>influxdb-csharp Contributors</Authors>
-    <TargetFrameworks>net45;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <VersionPrefix>1.1.1</VersionPrefix>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>InfluxDB.LineProtocol</AssemblyName>
@@ -16,17 +16,15 @@
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="System.Collections" Version="4.3.0" />
+    <PackageReference Include="System.Linq" Version="4.3.0" />
+    <PackageReference Include="System.Threading" Version="4.3.0" />
+    <PackageReference Include="System.Net.Http" Version="4.3.3" />
+    <PackageReference Include="System.Globalization" Version="4.3.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-    <PackageReference Include="System.Collections" Version="4.0.11" />
-    <PackageReference Include="System.Linq" Version="4.1.0" />
-    <PackageReference Include="System.Threading" Version="4.0.11" />
-    <PackageReference Include="System.Net.Http" Version="4.1.1" />
-    <PackageReference Include="System.Globalization" Version="4.0.11" />
+  <ItemGroup>
+    <PackageReference Include="System.Net.Sockets" Version="4.3.0" />
   </ItemGroup>
 </Project>

--- a/src/InfluxDB.LineProtocol/InfluxDB.LineProtocol.csproj
+++ b/src/InfluxDB.LineProtocol/InfluxDB.LineProtocol.csproj
@@ -16,15 +16,12 @@
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+  <ItemGroup>
     <PackageReference Include="System.Collections" Version="4.3.0" />
     <PackageReference Include="System.Linq" Version="4.3.0" />
     <PackageReference Include="System.Threading" Version="4.3.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.3" />
     <PackageReference Include="System.Globalization" Version="4.3.0" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="System.Net.Sockets" Version="4.3.0" />
   </ItemGroup>
 </Project>

--- a/test/Consoles/InfluxDb.UdpSupport.ConsoleTest/App.config
+++ b/test/Consoles/InfluxDb.UdpSupport.ConsoleTest/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7" />
+    </startup>
+</configuration>

--- a/test/Consoles/InfluxDb.UdpSupport.ConsoleTest/InfluxDb.UdpSupport.ConsoleTest.csproj
+++ b/test/Consoles/InfluxDb.UdpSupport.ConsoleTest/InfluxDb.UdpSupport.ConsoleTest.csproj
@@ -1,0 +1,62 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{1B138F1D-A772-4656-9142-442DEFB969E5}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>InfluxDb.UdpSupport.ConsoleTest</RootNamespace>
+    <AssemblyName>InfluxDb.UdpSupport.ConsoleTest</AssemblyName>
+    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\InfluxDB.Collector\InfluxDB.Collector.csproj">
+      <Project>{f690f3e3-d9f0-441a-9e70-4f70998bdd1b}</Project>
+      <Name>InfluxDB.Collector</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\src\InfluxDB.LineProtocol\InfluxDB.LineProtocol.csproj">
+      <Project>{069e0ac5-a2cf-4584-89a7-f475276e244c}</Project>
+      <Name>InfluxDB.LineProtocol</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/test/Consoles/InfluxDb.UdpSupport.ConsoleTest/Program.cs
+++ b/test/Consoles/InfluxDb.UdpSupport.ConsoleTest/Program.cs
@@ -1,0 +1,64 @@
+﻿using InfluxDB.Collector;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace InfluxDb.UdpSupport.ConsoleTest
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Task t = ListenAsync();
+            var process = Process.GetCurrentProcess();
+
+            Metrics.Collector = new CollectorConfiguration()
+                .Tag.With("process", Path.GetFileName(process.Id.ToString()))
+                .Batch.AtInterval(TimeSpan.FromSeconds(2))
+                .WriteTo.InfluxDB("udp://localhost:8999", "data")
+                .CreateCollector();
+
+            int i = 0;
+            while (true)
+            {
+                Metrics.Collector.Increment("test", i++ % 10);
+                Thread.Sleep(500);
+            }
+        }
+
+        private static async Task ListenAsync()
+        {
+            await Task.Delay(1);
+            var udpClient = new UdpClient(8999);
+            while (true)
+            {
+                try
+                {
+                    UdpReceiveResult result = await udpClient.ReceiveAsync();
+                    Byte[] receiveBytes = result.Buffer;
+                    string returnData = Encoding.UTF8.GetString(receiveBytes);
+                    IPEndPoint remoteIpEndPoint = result.RemoteEndPoint;
+
+                    // Uses the IPEndPoint object to determine which of these two hosts responded.
+                    Console.WriteLine($"This message was sent from {remoteIpEndPoint.Address} on their port number {remoteIpEndPoint.Port}");
+                    Console.WriteLine("This is the message you received:");
+                    Console.ForegroundColor = ConsoleColor.Yellow;
+                    Console.WriteLine(returnData);
+                    Console.ResetColor();
+                    Console.WriteLine("-----------------------------------------------------------------");
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine(e.ToString());
+                }
+            }
+        }
+    }
+}

--- a/test/Consoles/InfluxDb.UdpSupport.ConsoleTest/Program.cs
+++ b/test/Consoles/InfluxDb.UdpSupport.ConsoleTest/Program.cs
@@ -10,6 +10,31 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
+// influx-db command line:
+// start with
+// # influx
+// # show databases
+// # CREATE DATABASE {name}
+// # DROP DATABASE {name}
+// # precision rfc3339
+// # use <database>
+// # SHOW MEASUREMENTS
+// # SHOW MEASUREMENTS WITH MEASUREMENT =~ /v1\..*/ -- all fields from measurements that start with 'v1.' 
+// # SHOW SERIES
+// # SHOW SERIES [FROM <measurement_name> [WHERE <tag_key>='<tag_value>']]
+// # DROP SERIES FROM /v1.*\.end/
+// # SHOW TAG KEYS
+// # SHOW TAG KEYS FROM "v1.cos"
+// # SHOW FIELD KEYS
+// # SHOW FIELD KEYS FROM /v1\..*\.sin/   -- all fields from series that start with 'v1.' and end with '.sin'
+
+/*
+# influx
+docker run --name influx -p 8086:8086 -p 8089:8089/udp -p 8088:8088 -v C:\Docker\Volumes\influxdb\db:/var/lib/influxdb -v C:\Docker\Volumes\influxdb\config\influxdb.conf:/etc/influxdb/influxdb.conf:ro influxdb -config /etc/influxdb/influxdb.conf
+docker run -d -p 8083:8083 -p 8086:8086 -p 8089:4444/udp --expose 8083 --expose 8086 --expose 4444 -e UDP_DB="playground" tutum/influxdb
+
+*/
+
 namespace InfluxDb.UdpSupport.ConsoleTest
 {
     class Program
@@ -22,7 +47,7 @@ namespace InfluxDb.UdpSupport.ConsoleTest
             Metrics.Collector = new CollectorConfiguration()
                 .Tag.With("process", Path.GetFileName(process.Id.ToString()))
                 .Batch.AtInterval(TimeSpan.FromSeconds(2))
-                .WriteTo.InfluxDB("udp://localhost:8999", "data")
+                .WriteTo.InfluxDB("udp://localhost:8089", "data")
                 .CreateCollector();
 
             int i = 0;

--- a/test/Consoles/InfluxDb.UdpSupport.ConsoleTest/Properties/AssemblyInfo.cs
+++ b/test/Consoles/InfluxDb.UdpSupport.ConsoleTest/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("InfluxDb.UdpSupport.ConsoleTest")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("InfluxDb.UdpSupport.ConsoleTest")]
+[assembly: AssemblyCopyright("Copyright ©  2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("1b138f1d-a772-4656-9142-442defb969e5")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/test/InfluxDB.LineProtocol.Tests/InfluxDB.LineProtocol.Tests.csproj
+++ b/test/InfluxDB.LineProtocol.Tests/InfluxDB.LineProtocol.Tests.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
     <AssemblyName>InfluxDB.LineProtocol.Tests</AssemblyName>
     <PackageId>InfluxDB.LineProtocol.Tests</PackageId>
-    <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">2.0.0</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>2.0.0</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/InfluxDB.LineProtocol.Tests/InfluxDB.LineProtocol.Tests.csproj
+++ b/test/InfluxDB.LineProtocol.Tests/InfluxDB.LineProtocol.Tests.csproj
@@ -1,12 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;netcoreapp1.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
     <AssemblyName>InfluxDB.LineProtocol.Tests</AssemblyName>
     <PackageId>InfluxDB.LineProtocol.Tests</PackageId>
-    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">$(PackageTargetFallback);dnxcore50;portable-net45+win8</PackageTargetFallback>
-    <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">1.0.4</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">2.0.0</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -15,11 +13,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="System.ValueTuple" Version="4.3.0" />
-    <PackageReference Include="RichardSzalay.MockHttp" Version="1.5.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.0" />
+    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
+    <PackageReference Include="RichardSzalay.MockHttp" Version="3.2.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="xunit" Version="2.3.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Adding support to UDP channel.
Migrating the project to .NET Standard 2.0 and .NET 4.61 ( .NET Standard 2.0 is compatible with 4.6.1).
Update NuGet dependencies.
After merging this pull request I intend to fix some performance issue and move the code into more Dependency Injection friendly api.