### PR TITLE
Fix to issue 67: Add option to allow self signed certificate connection

### DIFF
--- a/src/InfluxDB.Collector/Configuration/CollectorEmitConfiguration.cs
+++ b/src/InfluxDB.Collector/Configuration/CollectorEmitConfiguration.cs
@@ -1,11 +1,12 @@
 ﻿using System;
+using System.Net.Http;
 using InfluxDB.Collector.Pipeline;
 
 namespace InfluxDB.Collector.Configuration
 {
     public abstract class CollectorEmitConfiguration
     {
-        public abstract CollectorConfiguration InfluxDB(Uri serverBaseAddress, string database, string username = null, string password = null);
+        public abstract CollectorConfiguration InfluxDB(Uri serverBaseAddress, string database, string username = null, string password = null, HttpMessageHandler handler = null);
 
         public CollectorConfiguration InfluxDB(string serverBaseAddress, string database, string username = null, string password = null)
         {

--- a/src/InfluxDB.Collector/Configuration/PipelinedCollectorEmitConfiguration.cs
+++ b/src/InfluxDB.Collector/Configuration/PipelinedCollectorEmitConfiguration.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Http;
 using InfluxDB.Collector.Pipeline;
 using InfluxDB.Collector.Pipeline.Emit;
 
@@ -20,12 +21,15 @@ namespace InfluxDB.Collector.Configuration
             _configuration = configuration;
         }
 
-        public override CollectorConfiguration InfluxDB(Uri serverBaseAddress, string database, string username = null, string password = null)
+        public override CollectorConfiguration InfluxDB(Uri serverBaseAddress, string database, string username = null, string password = null, HttpMessageHandler handler = null)
         {
+           if (handler == null)
+              handler = new HttpClientHandler();
+
             if (string.Compare(serverBaseAddress.Scheme, "udp", ignoreCase: true) == 0)
                 _client = new LineProtocolUdpClient(serverBaseAddress, database, username, password);
             else
-                _client = new LineProtocolClient(serverBaseAddress, database, username, password);
+                _client = new LineProtocolClient(handler, serverBaseAddress, database, username, password);
             return _configuration;
         }
 

--- a/src/InfluxDB.LineProtocol/Client/LineProtocolClient.cs
+++ b/src/InfluxDB.LineProtocol/Client/LineProtocolClient.cs
@@ -19,7 +19,7 @@ namespace InfluxDB.LineProtocol.Client
         {
         }
 
-        protected LineProtocolClient(
+        public LineProtocolClient(
                 HttpMessageHandler handler,
                 Uri serverBaseAddress,
                 string database,


### PR DESCRIPTION
Small change that allows users to pass a custom HttpMessageHandler to InfluxDb method, allowing to bypass certificate check for self signed certificates on server.

Usage:

```
         var handler = new HttpClientHandler
         {
            ServerCertificateCustomValidationCallback = (message, cert, chain, errors) => true
         };
         Metrics.Collector = new CollectorConfiguration()
            .Tag.With("host", Config["hostname"])
            .Batch.AtInterval(TimeSpan.FromSeconds(2))
            .WriteTo.InfluxDB(uri, Config["influxdbname"], Config["influxusername"], Config["influxpassword"], handler)
            .CreateCollector();
```